### PR TITLE
Add REST API endpoints, JWT auth, and demo seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,45 @@ npm run dev
 ```
 
 ### Seeding
-Seed data scripts will be added in a later milestone.
+Seed demo data (users, cars, pricing rules, sample booking):
+```bash
+cd backend
+python app/manage.py seed_demo
+```
+
+Demo credentials:
+- Admin: `admin` / `adminpass`
+- Manager: `manager` / `managerpass`
+- Customer: `customer` / `customerpass`
 
 ## Architecture Overview
 - **Backend**: Django 5 + DRF + SimpleJWT, structured under `backend/app` with domain apps (`users`, `cars`, `bookings`, `pricing`, `payments`, `reports`, `common`). Settings pull configuration from environment variables and enable CORS and JWT authentication. A minimal `/api/health/` endpoint is available for sanity checks.
 - **Frontend**: React + TypeScript (Vite) with React Router and Material UI. Routes for Login, Register, Cars, My Bookings, and Admin are scaffolded as placeholders. API access flows through a shared axios client using `VITE_API_URL`.
 - **Docker**: `docker-compose.yml` orchestrates Postgres, backend, and frontend services with a shared database volume.
 - **Quality Tooling**: Ruff/Black/Isort configurations for Python and ESLint/Prettier for the frontend; pytest scaffold for future backend tests.
+
+## API Endpoints (v2)
+Base URL: `/api/`
+
+| Area | Method | Path | Description |
+| --- | --- | --- | --- |
+| Auth | POST | `/auth/register/` | Register customer + profile |
+| Auth | POST | `/auth/login/` | Obtain JWT (access + refresh) |
+| Auth | POST | `/auth/refresh/` | Refresh JWT |
+| Auth | GET/PATCH | `/auth/me/` | Get/update current user profile |
+| Cars | GET | `/cars/` | List cars (filters + pagination) |
+| Cars | GET | `/cars/{id}/` | Car detail |
+| Cars | POST/PUT/PATCH/DELETE | `/cars/{id}/` | Admin/manager CRUD |
+| Pricing | GET | `/pricing/quote?car=&start=&end=` | Pricing quote from service |
+| Pricing | CRUD | `/pricing/rules/` | Pricing rules (admin only) |
+| Bookings | GET/POST | `/bookings/` | Create/list bookings (customers see own) |
+| Bookings | GET | `/bookings/{id}/` | Booking detail |
+| Bookings | POST | `/bookings/{id}/confirm/` | Manager confirm |
+| Bookings | POST | `/bookings/{id}/checkin/` | Manager check-in |
+| Bookings | POST | `/bookings/{id}/return/` | Manager mark returned |
+| Bookings | POST | `/bookings/{id}/cancel/` | Cancel booking |
+| Bookings | GET/POST | `/bookings/{id}/fines/` | List/add fines (manager adds) |
+| Payments | POST | `/bookings/{id}/deposit/hold|release|forfeit/` | Deposit actions |
+| Payments | POST | `/bookings/{id}/invoice/pay/` | Pay invoice (mock) |
+| Reports | ANY | `/reports/*` | Placeholder returns 501 |
+| Schema | GET | `/schema/` | Basic OpenAPI schema |

--- a/backend/app/apps/bookings/invoice_builder.py
+++ b/backend/app/apps/bookings/invoice_builder.py
@@ -20,12 +20,16 @@ class InvoiceBuilder:
 
     def add_pricing_breakdown(self, breakdown: Iterable[dict]) -> None:
         for item in breakdown:
-            self.add_charge(item.get("name", "Charge"), item.get("amount", 0), item.get("metadata", {}))
+            self.add_charge(
+                item.get("name", "Charge"), item.get("amount", 0), item.get("metadata", {})
+            )
 
     def add_fines(self, fines: Iterable) -> None:
         for fine in fines:
             self.add_charge(
-                f"Fine: {fine.get_type_display()}", fine.amount, {"type": fine.type, "fine_id": str(fine.id)}
+                f"Fine: {fine.get_type_display()}",
+                fine.amount,
+                {"type": fine.type, "fine_id": str(fine.id)},
             )
 
     def build(self) -> Invoice:

--- a/backend/app/apps/bookings/models.py
+++ b/backend/app/apps/bookings/models.py
@@ -16,7 +16,9 @@ class Booking(models.Model):
         CANCELED = "canceled", "Canceled"
 
     id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
-    customer = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="bookings")
+    customer = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="bookings"
+    )
     car = models.ForeignKey(Car, on_delete=models.CASCADE, related_name="bookings")
     start_date = models.DateField()
     end_date = models.DateField()

--- a/backend/app/apps/bookings/serializers.py
+++ b/backend/app/apps/bookings/serializers.py
@@ -1,0 +1,80 @@
+from rest_framework import serializers
+
+from apps.cars.serializers import CarSerializer
+from apps.cars.models import Car
+
+from .models import Booking, Deposit, Fine, Invoice
+
+
+class FineSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Fine
+        fields = ["id", "type", "amount", "notes", "assessed_at"]
+        read_only_fields = ["id", "assessed_at"]
+
+
+class DepositSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Deposit
+        fields = ["id", "amount", "status", "txn_ref", "created_at", "updated_at"]
+        read_only_fields = ["id", "status", "txn_ref", "created_at", "updated_at"]
+
+
+class InvoiceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Invoice
+        fields = [
+            "id",
+            "breakdown",
+            "total",
+            "paid_at",
+            "method",
+            "payment_reference",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = [
+            "id",
+            "breakdown",
+            "total",
+            "paid_at",
+            "method",
+            "payment_reference",
+            "created_at",
+            "updated_at",
+        ]
+
+
+class BookingSerializer(serializers.ModelSerializer):
+    car = CarSerializer(read_only=True)
+    car_id = serializers.PrimaryKeyRelatedField(
+        source="car", queryset=Car.objects.all(), write_only=True
+    )
+    fines = FineSerializer(many=True, read_only=True)
+    deposit = DepositSerializer(read_only=True)
+    invoice = InvoiceSerializer(read_only=True)
+
+    class Meta:
+        model = Booking
+        fields = [
+            "id",
+            "customer",
+            "car",
+            "car_id",
+            "start_date",
+            "end_date",
+            "status",
+            "created_at",
+            "updated_at",
+            "fines",
+            "deposit",
+            "invoice",
+        ]
+        read_only_fields = ["id", "customer", "status", "created_at", "updated_at", "car"]
+
+    def validate(self, attrs):
+        start_date = attrs.get("start_date")
+        end_date = attrs.get("end_date")
+        if start_date and end_date and end_date <= start_date:
+            raise serializers.ValidationError("End date must be after start date.")
+        return attrs

--- a/backend/app/apps/bookings/services.py
+++ b/backend/app/apps/bookings/services.py
@@ -37,7 +37,9 @@ class BookingService:
             raise ValueError("End date must be after start date")
         if self.has_overlaps(car, start_date, end_date):
             raise BookingOverlapError("Car already booked for the selected period")
-        return Booking.objects.create(customer=customer, car=car, start_date=start_date, end_date=end_date)
+        return Booking.objects.create(
+            customer=customer, car=car, start_date=start_date, end_date=end_date
+        )
 
     def confirm_booking(self, booking: Booking) -> Booking:
         return self.state_machine.transition(booking, Booking.Status.CONFIRMED)
@@ -51,7 +53,9 @@ class BookingService:
     def cancel_booking(self, booking: Booking) -> Booking:
         return self.state_machine.transition(booking, Booking.Status.CANCELED)
 
-    def apply_fine(self, booking: Booking, fine_type: str, amount: Decimal, notes: str = "") -> Fine:
+    def apply_fine(
+        self, booking: Booking, fine_type: str, amount: Decimal, notes: str = ""
+    ) -> Fine:
         fine = Fine.objects.create(booking=booking, type=fine_type, amount=amount, notes=notes)
         event_bus.publish(FINE_APPLIED, fine)
         return fine

--- a/backend/app/apps/bookings/urls.py
+++ b/backend/app/apps/bookings/urls.py
@@ -1,0 +1,8 @@
+from rest_framework.routers import DefaultRouter
+
+from .views import BookingViewSet
+
+router = DefaultRouter()
+router.register("", BookingViewSet, basename="booking")
+
+urlpatterns = router.urls

--- a/backend/app/apps/bookings/views.py
+++ b/backend/app/apps/bookings/views.py
@@ -1,0 +1,201 @@
+from decimal import Decimal, InvalidOperation
+
+from rest_framework import permissions, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+
+from apps.common.permissions import IsManagerOrAdmin
+from apps.payments.services import PaymentService
+
+from .models import Booking
+from .serializers import BookingSerializer, FineSerializer
+from .services import BookingOverlapError, BookingService, InvalidStateTransition
+
+
+class BookingViewSet(viewsets.ModelViewSet):
+    serializer_class = BookingSerializer
+    permission_classes = [permissions.IsAuthenticated]
+    http_method_names = ["get", "post"]
+
+    @property
+    def booking_service(self) -> BookingService:
+        if not hasattr(self, "_booking_service"):
+            self._booking_service = BookingService()
+        return self._booking_service
+
+    @property
+    def payment_service(self) -> PaymentService:
+        if not hasattr(self, "_payment_service"):
+            self._payment_service = PaymentService()
+        return self._payment_service
+
+    def get_queryset(self):
+        base_qs = Booking.objects.select_related("customer", "car").prefetch_related("fines")
+        user = self.request.user
+        if user.role in (user.Role.ADMIN, user.Role.MANAGER):
+            return base_qs
+        return base_qs.filter(customer=user)
+
+    def perform_create(self, serializer):
+        try:
+            booking = self.booking_service.create_booking(
+                customer=self.request.user,
+                car=serializer.validated_data["car"],
+                start_date=serializer.validated_data["start_date"],
+                end_date=serializer.validated_data["end_date"],
+            )
+        except (ValueError, BookingOverlapError) as exc:
+            raise ValidationError(str(exc))
+        serializer.instance = booking
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+    @action(detail=True, methods=["post"], permission_classes=[IsManagerOrAdmin])
+    def confirm(self, request, pk=None):
+        booking = self.get_object()
+        try:
+            booking = self.booking_service.confirm_booking(booking)
+        except InvalidStateTransition as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(self.get_serializer(booking).data)
+
+    @action(detail=True, methods=["post"], permission_classes=[IsManagerOrAdmin])
+    def checkin(self, request, pk=None):
+        booking = self.get_object()
+        try:
+            booking = self.booking_service.checkin_booking(booking)
+        except InvalidStateTransition as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(self.get_serializer(booking).data)
+
+    @action(detail=True, methods=["post"], url_path="return", permission_classes=[IsManagerOrAdmin])
+    def return_booking(self, request, pk=None):
+        booking = self.get_object()
+        try:
+            booking = self.booking_service.return_booking(booking)
+        except InvalidStateTransition as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(self.get_serializer(booking).data)
+
+    @action(detail=True, methods=["post"])
+    def cancel(self, request, pk=None):
+        booking = self.get_object()
+        user = request.user
+        if user.role not in (user.Role.MANAGER, user.Role.ADMIN) and booking.customer != user:
+            return Response(
+                {"detail": "Not allowed to cancel this booking."}, status=status.HTTP_403_FORBIDDEN
+            )
+        try:
+            booking = self.booking_service.cancel_booking(booking)
+        except InvalidStateTransition as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(self.get_serializer(booking).data)
+
+    @action(detail=True, methods=["get", "post"], url_path="fines")
+    def fines(self, request, pk=None):
+        booking = self.get_object()
+        if request.method.lower() == "get":
+            fines = booking.fines.all()
+            return Response(FineSerializer(fines, many=True).data)
+
+        if request.user.role not in (request.user.Role.ADMIN, request.user.Role.MANAGER):
+            return Response(
+                {"detail": "Only managers can add fines."}, status=status.HTTP_403_FORBIDDEN
+            )
+        serializer = FineSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        fine_type = serializer.validated_data["type"]
+        try:
+            amount = Decimal(serializer.validated_data["amount"])
+        except (InvalidOperation, TypeError):
+            raise ValidationError("Invalid fine amount.")
+        notes = serializer.validated_data.get("notes", "")
+        fine = self.booking_service.apply_fine(booking, fine_type, amount, notes)
+        return Response(FineSerializer(fine).data, status=status.HTTP_201_CREATED)
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="deposit/hold",
+        permission_classes=[IsManagerOrAdmin],
+    )
+    def hold_deposit(self, request, pk=None):
+        booking = self.get_object()
+        amount = request.data.get("amount")
+        if amount is None:
+            return Response({"detail": "amount is required."}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            decimal_amount = Decimal(amount)
+        except (InvalidOperation, TypeError):
+            raise ValidationError("Invalid deposit amount.")
+        deposit = self.payment_service.hold_deposit(booking, decimal_amount)
+        return Response(
+            {"id": str(deposit.id), "status": deposit.status, "amount": str(deposit.amount)}
+        )
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="deposit/release",
+        permission_classes=[IsManagerOrAdmin],
+    )
+    def release_deposit(self, request, pk=None):
+        booking = self.get_object()
+        if not hasattr(booking, "deposit"):
+            return Response(
+                {"detail": "No deposit to release."}, status=status.HTTP_400_BAD_REQUEST
+            )
+        partial_flag = str(request.data.get("partial", False)).lower() in ("true", "1", "yes")
+        deposit = self.payment_service.release_deposit(booking.deposit, partial=partial_flag)
+        return Response(
+            {"id": str(deposit.id), "status": deposit.status, "amount": str(deposit.amount)}
+        )
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="deposit/forfeit",
+        permission_classes=[IsManagerOrAdmin],
+    )
+    def forfeit_deposit(self, request, pk=None):
+        booking = self.get_object()
+        if not hasattr(booking, "deposit"):
+            return Response(
+                {"detail": "No deposit to forfeit."}, status=status.HTTP_400_BAD_REQUEST
+            )
+        deposit = self.payment_service.forfeit_deposit(booking.deposit)
+        return Response(
+            {"id": str(deposit.id), "status": deposit.status, "amount": str(deposit.amount)}
+        )
+
+    @action(detail=True, methods=["post"], url_path="invoice/pay")
+    def pay_invoice(self, request, pk=None):
+        booking = self.get_object()
+        method = request.data.get("method", "card")
+        if booking.customer != request.user and request.user.role not in (
+            request.user.Role.ADMIN,
+            request.user.Role.MANAGER,
+        ):
+            return Response(
+                {"detail": "Not allowed to pay for this booking."}, status=status.HTTP_403_FORBIDDEN
+            )
+
+        invoice = getattr(booking, "invoice", None)
+        if not invoice:
+            invoice = self.booking_service.build_invoice(booking)["invoice"]
+        invoice = self.payment_service.pay_invoice(invoice, method)
+        return Response({"id": str(invoice.id), "status": "paid", "method": invoice.method})
+
+    @action(detail=True, methods=["get"], url_path="quote")
+    def pricing_quote(self, request, pk=None):
+        booking = self.get_object()
+        quote = self.booking_service.pricing_service.quote(
+            booking.car, booking.start_date, booking.end_date
+        )
+        return Response(quote)

--- a/backend/app/apps/cars/serializers.py
+++ b/backend/app/apps/cars/serializers.py
@@ -1,0 +1,21 @@
+from rest_framework import serializers
+
+from .models import Car
+
+
+class CarSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Car
+        fields = [
+            "id",
+            "make",
+            "model",
+            "year",
+            "vin",
+            "type",
+            "base_price_per_day",
+            "status",
+            "mileage",
+            "last_service_at",
+        ]
+        read_only_fields = ["id"]

--- a/backend/app/apps/cars/urls.py
+++ b/backend/app/apps/cars/urls.py
@@ -1,0 +1,8 @@
+from rest_framework.routers import DefaultRouter
+
+from .views import CarViewSet
+
+router = DefaultRouter()
+router.register("", CarViewSet, basename="car")
+
+urlpatterns = router.urls

--- a/backend/app/apps/cars/views.py
+++ b/backend/app/apps/cars/views.py
@@ -1,0 +1,47 @@
+from rest_framework import permissions, viewsets
+from rest_framework.response import Response
+from django.db.models import Q
+
+from apps.common.permissions import IsManagerOrAdmin
+
+from .models import Car
+from .serializers import CarSerializer
+
+
+class CarViewSet(viewsets.ModelViewSet):
+    serializer_class = CarSerializer
+    queryset = Car.objects.all()
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_permissions(self):
+        if self.action in ["list", "retrieve"]:
+            return [permissions.IsAuthenticated()]
+        return [IsManagerOrAdmin()]
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        queryset = self._apply_filters(queryset, request)
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
+    def _apply_filters(self, queryset, request):
+        params = request.query_params
+        if make := params.get("make"):
+            queryset = queryset.filter(make__icontains=make)
+        if model := params.get("model"):
+            queryset = queryset.filter(model__icontains=model)
+        if car_type := params.get("type"):
+            queryset = queryset.filter(type__iexact=car_type)
+        if status := params.get("status"):
+            queryset = queryset.filter(status=status)
+        if year_min := params.get("year_min"):
+            queryset = queryset.filter(year__gte=year_min)
+        if year_max := params.get("year_max"):
+            queryset = queryset.filter(year__lte=year_max)
+        if search := params.get("search"):
+            queryset = queryset.filter(Q(model__icontains=search) | Q(make__icontains=search))
+        return queryset.order_by("make", "model", "year")

--- a/backend/app/apps/common/management/__init__.py
+++ b/backend/app/apps/common/management/__init__.py
@@ -1,0 +1,1 @@
+# Package for common management commands.

--- a/backend/app/apps/common/management/commands/__init__.py
+++ b/backend/app/apps/common/management/commands/__init__.py
@@ -1,0 +1,1 @@
+# Package for management commands.

--- a/backend/app/apps/common/management/commands/seed_demo.py
+++ b/backend/app/apps/common/management/commands/seed_demo.py
@@ -1,0 +1,130 @@
+from datetime import date, timedelta
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from apps.bookings.models import Booking
+from apps.bookings.services import BookingService
+from apps.cars.models import Car
+from apps.pricing.models import PricingRule
+from apps.users.models import CustomerProfile
+
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Seed demo data for development environments."
+
+    def handle(self, *args, **options):
+        with transaction.atomic():
+            admin = self._get_or_create_user(
+                username="admin",
+                email="admin@example.com",
+                password="adminpass",
+                role=User.Role.ADMIN,
+            )
+            manager = self._get_or_create_user(
+                username="manager",
+                email="manager@example.com",
+                password="managerpass",
+                role=User.Role.MANAGER,
+            )
+            customer = self._get_or_create_user(
+                username="customer",
+                email="customer@example.com",
+                password="customerpass",
+                role=User.Role.CUSTOMER,
+            )
+            CustomerProfile.objects.get_or_create(
+                user=customer,
+                defaults={
+                    "full_name": "Demo Customer",
+                    "phone": "555-1000",
+                    "driver_license_no": "DL-12345",
+                    "address": "123 Demo Street",
+                },
+            )
+
+            self.stdout.write(self.style.SUCCESS("Users ready: admin, manager, customer."))
+            self._seed_cars()
+            self._seed_pricing_rules()
+            self._seed_bookings(customer)
+            self.stdout.write(self.style.SUCCESS("Demo data seeded."))
+
+    def _get_or_create_user(self, username: str, email: str, password: str, role: str) -> User:
+        user, created = User.objects.get_or_create(
+            username=username, defaults={"email": email, "role": role}
+        )
+        if created or not user.check_password(password):
+            user.set_password(password)
+            user.role = role
+            user.email = email
+            user.save()
+        return user
+
+    def _seed_cars(self) -> None:
+        car_data = [
+            ("Toyota", "Camry", 2022, "VIN00000000000001", "sedan", "85.00"),
+            ("Honda", "Civic", 2021, "VIN00000000000002", "sedan", "78.00"),
+            ("Ford", "Escape", 2020, "VIN00000000000003", "suv", "95.00"),
+            ("Tesla", "Model 3", 2023, "VIN00000000000004", "sedan", "140.00"),
+            ("Chevrolet", "Tahoe", 2019, "VIN00000000000005", "suv", "120.00"),
+            ("BMW", "X5", 2022, "VIN00000000000006", "suv", "160.00"),
+            ("Audi", "A4", 2021, "VIN00000000000007", "sedan", "130.00"),
+            ("Hyundai", "Elantra", 2020, "VIN00000000000008", "sedan", "70.00"),
+            ("Kia", "Sorento", 2022, "VIN00000000000009", "suv", "98.00"),
+            ("Jeep", "Wrangler", 2021, "VIN00000000000010", "suv", "150.00"),
+        ]
+        for make, model, year, vin, car_type, base_price in car_data:
+            Car.objects.get_or_create(
+                vin=vin,
+                defaults={
+                    "make": make,
+                    "model": model,
+                    "year": year,
+                    "type": car_type,
+                    "base_price_per_day": Decimal(base_price),
+                },
+            )
+        self.stdout.write(self.style.SUCCESS("Cars ready."))
+
+    def _seed_pricing_rules(self) -> None:
+        PricingRule.objects.get_or_create(
+            name="Summer uplift",
+            strategy_type=PricingRule.StrategyType.SEASONAL,
+            params={"months": [6, 7, 8], "multiplier": 1.15},
+            defaults={"active": True},
+        )
+        PricingRule.objects.get_or_create(
+            name="Weekly discount",
+            strategy_type=PricingRule.StrategyType.DURATION_DISCOUNT,
+            params={"min_days": 7, "discount_rate": 0.1},
+            defaults={"active": True},
+        )
+        PricingRule.objects.get_or_create(
+            name="Annual depreciation",
+            strategy_type=PricingRule.StrategyType.YEAR_DEPRECIATION,
+            params={"rate": 0.03},
+            defaults={"active": True},
+        )
+        self.stdout.write(self.style.SUCCESS("Pricing rules ready."))
+
+    def _seed_bookings(self, customer: User) -> None:
+        service = BookingService()
+        cars = list(Car.objects.all()[:2])
+        if not cars:
+            return
+        start = date.today() + timedelta(days=1)
+        end = start + timedelta(days=3)
+        existing = Booking.objects.filter(customer=customer).first()
+        if existing:
+            return
+        booking = service.create_booking(
+            customer=customer, car=cars[0], start_date=start, end_date=end
+        )
+        service.confirm_booking(booking)
+        service.checkin_booking(booking)
+        self.stdout.write(self.style.SUCCESS("Sample booking created."))

--- a/backend/app/apps/common/permissions.py
+++ b/backend/app/apps/common/permissions.py
@@ -1,0 +1,17 @@
+from rest_framework.permissions import BasePermission
+
+from apps.users.models import User
+
+
+class IsManagerOrAdmin(BasePermission):
+    def has_permission(self, request, view):
+        user: User | None = getattr(request, "user", None)
+        return bool(
+            user and user.is_authenticated and user.role in (User.Role.MANAGER, User.Role.ADMIN)
+        )
+
+
+class IsAdmin(BasePermission):
+    def has_permission(self, request, view):
+        user: User | None = getattr(request, "user", None)
+        return bool(user and user.is_authenticated and user.role == User.Role.ADMIN)

--- a/backend/app/apps/pricing/serializers.py
+++ b/backend/app/apps/pricing/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+from .models import PricingRule
+
+
+class PricingRuleSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PricingRule
+        fields = ["id", "name", "strategy_type", "params", "active", "created_at", "updated_at"]
+        read_only_fields = ["id", "created_at", "updated_at"]

--- a/backend/app/apps/pricing/strategies.py
+++ b/backend/app/apps/pricing/strategies.py
@@ -55,7 +55,9 @@ class PricingResult:
 
 
 class PricingStrategy:
-    def apply(self, context: PricingContext, result: PricingResult) -> None:  # pragma: no cover - interface
+    def apply(
+        self, context: PricingContext, result: PricingResult
+    ) -> None:  # pragma: no cover - interface
         raise NotImplementedError
 
 
@@ -136,4 +138,6 @@ class SeasonalStrategy(PricingStrategy):
             adjustment = result.total * (multiplier - 1)
             if adjustment == 0:
                 continue
-            result.add_item(rule.name or self.label, adjustment, metadata={"multiplier": float(multiplier)})
+            result.add_item(
+                rule.name or self.label, adjustment, metadata={"multiplier": float(multiplier)}
+            )

--- a/backend/app/apps/pricing/urls.py
+++ b/backend/app/apps/pricing/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+from rest_framework.routers import DefaultRouter
+
+from .views import PricingRuleViewSet, QuoteView
+
+router = DefaultRouter()
+router.register("rules", PricingRuleViewSet, basename="pricing-rule")
+
+urlpatterns = [
+    path("quote/", QuoteView.as_view(), name="pricing-quote"),
+]
+
+urlpatterns += router.urls

--- a/backend/app/apps/pricing/views.py
+++ b/backend/app/apps/pricing/views.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+
+from django.shortcuts import get_object_or_404
+from rest_framework import permissions, status, viewsets
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.cars.models import Car
+from apps.common.permissions import IsAdmin
+from apps.pricing.services import PricingService
+
+from .models import PricingRule
+from .serializers import PricingRuleSerializer
+
+
+class QuoteView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        car_id = request.query_params.get("car")
+        start = request.query_params.get("start")
+        end = request.query_params.get("end")
+        if not (car_id and start and end):
+            return Response(
+                {"detail": "car, start, and end query parameters are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            start_date = datetime.strptime(start, "%Y-%m-%d").date()
+            end_date = datetime.strptime(end, "%Y-%m-%d").date()
+        except ValueError:
+            return Response(
+                {"detail": "Invalid date format, expected YYYY-MM-DD."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        car = get_object_or_404(Car, id=car_id)
+        try:
+            quote = PricingService().quote(car, start_date, end_date)
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(quote)
+
+
+class PricingRuleViewSet(viewsets.ModelViewSet):
+    queryset = PricingRule.objects.all()
+    serializer_class = PricingRuleSerializer
+    permission_classes = [IsAdmin]

--- a/backend/app/apps/reports/urls.py
+++ b/backend/app/apps/reports/urls.py
@@ -4,4 +4,5 @@ from .views import reports_placeholder
 
 urlpatterns = [
     path("", reports_placeholder, name="reports-placeholder"),
+    path("<path:any_path>/", reports_placeholder, name="reports-placeholder-any"),
 ]

--- a/backend/app/apps/users/serializers.py
+++ b/backend/app/apps/users/serializers.py
@@ -1,0 +1,76 @@
+from django.contrib.auth import get_user_model
+from rest_framework import serializers
+
+from apps.users.models import CustomerProfile
+
+
+User = get_user_model()
+
+
+class CustomerProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CustomerProfile
+        fields = ["full_name", "phone", "driver_license_no", "address"]
+
+
+class UserSerializer(serializers.ModelSerializer):
+    profile = CustomerProfileSerializer(read_only=True)
+
+    class Meta:
+        model = User
+        fields = ["id", "username", "email", "role", "profile"]
+        read_only_fields = ["id", "role"]
+
+
+class RegisterSerializer(serializers.Serializer):
+    username = serializers.CharField()
+    email = serializers.EmailField()
+    password = serializers.CharField(write_only=True, min_length=8)
+    full_name = serializers.CharField()
+    phone = serializers.CharField()
+    driver_license_no = serializers.CharField()
+    address = serializers.CharField()
+
+    def validate_username(self, value):
+        if User.objects.filter(username=value).exists():
+            raise serializers.ValidationError("Username already taken.")
+        return value
+
+    def validate_email(self, value):
+        if User.objects.filter(email=value).exists():
+            raise serializers.ValidationError("Email already registered.")
+        return value
+
+    def create(self, validated_data):
+        profile_fields = {
+            "full_name": validated_data.pop("full_name"),
+            "phone": validated_data.pop("phone"),
+            "driver_license_no": validated_data.pop("driver_license_no"),
+            "address": validated_data.pop("address"),
+        }
+        user = User.objects.create_user(
+            role=User.Role.CUSTOMER,
+            **validated_data,
+        )
+        CustomerProfile.objects.create(user=user, **profile_fields)
+        return user
+
+
+class MeSerializer(serializers.ModelSerializer):
+    profile = CustomerProfileSerializer()
+
+    class Meta:
+        model = User
+        fields = ["id", "username", "email", "role", "profile"]
+        read_only_fields = ["id", "username", "role"]
+
+    def update(self, instance, validated_data):
+        profile_data = validated_data.pop("profile", {})
+        instance.email = validated_data.get("email", instance.email)
+        instance.save(update_fields=["email"])
+
+        profile, _ = CustomerProfile.objects.get_or_create(user=instance)
+        for field, value in profile_data.items():
+            setattr(profile, field, value)
+        profile.save()
+        return instance

--- a/backend/app/apps/users/urls.py
+++ b/backend/app/apps/users/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from .views import LoginView, MeView, RefreshView, RegisterView
+
+urlpatterns = [
+    path("register/", RegisterView.as_view(), name="auth-register"),
+    path("login/", LoginView.as_view(), name="auth-login"),
+    path("refresh/", RefreshView.as_view(), name="auth-refresh"),
+    path("me/", MeView.as_view(), name="auth-me"),
+]

--- a/backend/app/apps/users/views.py
+++ b/backend/app/apps/users/views.py
@@ -1,0 +1,47 @@
+from django.contrib.auth import get_user_model
+from rest_framework import permissions, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+
+from .serializers import MeSerializer, RegisterSerializer, UserSerializer
+
+
+User = get_user_model()
+
+
+class RegisterView(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request):
+        serializer = RegisterSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+        return Response(UserSerializer(user).data, status=status.HTTP_201_CREATED)
+
+
+class MeView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        return Response(MeSerializer(request.user).data)
+
+    def put(self, request):
+        serializer = MeSerializer(instance=request.user, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
+
+    def patch(self, request):
+        serializer = MeSerializer(instance=request.user, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
+
+
+class LoginView(TokenObtainPairView):
+    permission_classes = [permissions.AllowAny]
+
+
+class RefreshView(TokenRefreshView):
+    permission_classes = [permissions.AllowAny]

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from datetime import timedelta
 from pathlib import Path
 
@@ -5,6 +7,9 @@ from environs import Env
 
 env = Env()
 env.read_env()
+TESTING = any(
+    arg in ("test", "pytest") or "pytest" in arg or arg.startswith("-k") for arg in sys.argv
+)
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -34,7 +39,9 @@ INSTALLED_APPS = [
 ]
 
 # Database
-USE_SQLITE_FOR_TESTS = env.bool("USE_SQLITE_FOR_TESTS", False)
+USE_SQLITE_FOR_TESTS = env.bool(
+    "USE_SQLITE_FOR_TESTS", TESTING or "PYTEST_CURRENT_TEST" in os.environ
+)
 
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
@@ -106,8 +113,11 @@ REST_FRAMEWORK = {
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ),
     "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.AllowAny",
+        "rest_framework.permissions.IsAuthenticated",
     ],
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 10,
+    "DEFAULT_SCHEMA_CLASS": "rest_framework.schemas.openapi.AutoSchema",
 }
 
 SIMPLE_JWT = {

--- a/backend/app/core/urls.py
+++ b/backend/app/core/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.http import JsonResponse
 from django.urls import include, path
+from rest_framework.schemas import get_schema_view
 
 
 def healthcheck_view(_request):
@@ -10,6 +11,10 @@ def healthcheck_view(_request):
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/health/", healthcheck_view, name="healthcheck"),
+    path("api/schema/", get_schema_view(title="Car Rental API"), name="api-schema"),
+    path("api/auth/", include("apps.users.urls")),
+    path("api/cars/", include("apps.cars.urls")),
+    path("api/bookings/", include("apps.bookings.urls")),
+    path("api/pricing/", include("apps.pricing.urls")),
     path("api/reports/", include("apps.reports.urls")),
-    path("api/", include("apps.common.urls")),
 ]


### PR DESCRIPTION
## Summary
- add JWT-backed auth endpoints for register/login/me with customer profile handling
- expose DRF viewsets for cars, pricing, bookings, and payment actions with role-aware permissions and validation
- add demo seeding command plus README updates for API table and sample credentials

## Testing
- USE_SQLITE_FOR_TESTS=1 pytest ../tests -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69432cfc0ee4833398eb8d40c8121faa)