### PR TITLE
Implement React frontend with auth and booking workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.egg-info/
 .env
 .env.*
+!.env.example
 venv/
 .venv/
 .envrc

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ npm install
 npm run dev
 ```
 
+### Frontend (React + TypeScript)
+- Environment: set `VITE_API_URL` in `frontend/.env` (example in `.env.example` points to `http://localhost:8000/api`).
+- Core tools: Vite + React Router + React Hook Form + Axios + MUI. Auth is JWT-based (SimpleJWT) with automatic token refresh and protected routes per role.
+- Useful scripts:
+  - `npm run dev` — start the Vite dev server (http://localhost:5173).
+  - `npm run build` — type-check + production build.
+  - `npm run lint` — run ESLint.
+
+Screenshots (placeholders):
+- `docs/screenshots/login.png` — Login + registration.
+- `docs/screenshots/cars.png` — Cars listing + detail/quote flow.
+- `docs/screenshots/bookings.png` — Customer bookings + manager queue.
+
 ### Seeding
 Seed demo data (users, cars, pricing rules, sample booking):
 ```bash
@@ -54,7 +67,7 @@ Demo credentials:
 
 ## Architecture Overview
 - **Backend**: Django 5 + DRF + SimpleJWT, structured under `backend/app` with domain apps (`users`, `cars`, `bookings`, `pricing`, `payments`, `reports`, `common`). Settings pull configuration from environment variables and enable CORS and JWT authentication. A minimal `/api/health/` endpoint is available for sanity checks.
-- **Frontend**: React + TypeScript (Vite) with React Router and Material UI. Routes for Login, Register, Cars, My Bookings, and Admin are scaffolded as placeholders. API access flows through a shared axios client using `VITE_API_URL`.
+- **Frontend**: React + TypeScript (Vite) with React Router and Material UI. The app includes auth (login/register, JWT refresh), public vehicle browsing with quotes/booking, customer booking detail pages, and manager/admin tools for car CRUD plus booking queue controls. API access flows through a shared axios client using `VITE_API_URL`.
 - **Docker**: `docker-compose.yml` orchestrates Postgres, backend, and frontend services with a shared database volume.
 - **Quality Tooling**: Ruff/Black/Isort configurations for Python and ESLint/Prettier for the frontend; pytest scaffold for future backend tests.
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000/api

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,9 +2,14 @@ import { Container } from '@mui/material'
 import { Route, Routes } from 'react-router-dom'
 
 import NavBar from './components/NavBar'
+import ProtectedRoute from './components/ProtectedRoute'
 import AdminPage from './pages/AdminPage'
+import BookingDetailPage from './pages/BookingDetailPage'
+import CarDetailPage from './pages/CarDetailPage'
 import CarsPage from './pages/CarsPage'
 import LoginPage from './pages/LoginPage'
+import ManageBookingsPage from './pages/ManageBookingsPage'
+import ManageCarsPage from './pages/ManageCarsPage'
 import MyBookingsPage from './pages/MyBookingsPage'
 import RegisterPage from './pages/RegisterPage'
 
@@ -17,8 +22,55 @@ const App = () => {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/cars" element={<CarsPage />} />
-          <Route path="/bookings" element={<MyBookingsPage />} />
-          <Route path="/admin" element={<AdminPage />} />
+          <Route path="/cars/:carId" element={<CarDetailPage />} />
+          <Route
+            path="/bookings"
+            element={
+              <ProtectedRoute>
+                <MyBookingsPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/bookings/:bookingId"
+            element={
+              <ProtectedRoute>
+                <BookingDetailPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/admin"
+            element={
+              <ProtectedRoute roles={['manager', 'admin']}>
+                <AdminPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/manage/cars"
+            element={
+              <ProtectedRoute roles={['manager', 'admin']}>
+                <ManageCarsPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/manage/bookings"
+            element={
+              <ProtectedRoute roles={['manager', 'admin']}>
+                <ManageBookingsPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/manage/bookings/:bookingId"
+            element={
+              <ProtectedRoute roles={['manager', 'admin']}>
+                <BookingDetailPage />
+              </ProtectedRoute>
+            }
+          />
           <Route path="*" element={<CarsPage />} />
         </Routes>
       </Container>

--- a/frontend/src/api/authStorage.ts
+++ b/frontend/src/api/authStorage.ts
@@ -1,0 +1,31 @@
+import { AuthTokens } from '../types'
+
+type Listener = (tokens: AuthTokens | null) => void
+
+const STORAGE_KEY = 'car-rental-auth'
+const listeners = new Set<Listener>()
+
+export const getStoredTokens = (): AuthTokens | null => {
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as AuthTokens
+  } catch {
+    return null
+  }
+}
+
+export const setStoredTokens = (tokens: AuthTokens) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(tokens))
+  listeners.forEach((listener) => listener(tokens))
+}
+
+export const clearStoredTokens = () => {
+  localStorage.removeItem(STORAGE_KEY)
+  listeners.forEach((listener) => listener(null))
+}
+
+export const subscribeToAuthChanges = (listener: Listener) => {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,8 +1,64 @@
 import axios from 'axios'
 
+declare module 'axios' {
+  export interface AxiosRequestConfig {
+    _retry?: boolean
+  }
+}
+
+import { clearStoredTokens, getStoredTokens, setStoredTokens } from './authStorage'
+
 const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8000/api',
   withCredentials: true
 })
+
+apiClient.interceptors.request.use((config) => {
+  const tokens = getStoredTokens()
+  if (tokens?.access) {
+    config.headers.Authorization = `Bearer ${tokens.access}`
+  }
+  return config
+})
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      !originalRequest.url?.includes('/auth/login') &&
+      !originalRequest.url?.includes('/auth/refresh')
+    ) {
+      const tokens = getStoredTokens()
+      if (!tokens?.refresh) {
+        clearStoredTokens()
+        return Promise.reject(error)
+      }
+
+      originalRequest._retry = true
+      try {
+        const refreshResponse = await axios.post(
+          `${apiClient.defaults.baseURL}/auth/refresh/`,
+          { refresh: tokens.refresh },
+          { withCredentials: true }
+        )
+        const newTokens = {
+          access: refreshResponse.data.access,
+          refresh: refreshResponse.data.refresh ?? tokens.refresh
+        }
+        setStoredTokens(newTokens)
+        originalRequest.headers.Authorization = `Bearer ${newTokens.access}`
+        return apiClient(originalRequest)
+      } catch (refreshError) {
+        clearStoredTokens()
+        return Promise.reject(refreshError)
+      }
+    }
+
+    return Promise.reject(error)
+  }
+)
 
 export default apiClient

--- a/frontend/src/components/ErrorAlert.tsx
+++ b/frontend/src/components/ErrorAlert.tsx
@@ -1,0 +1,12 @@
+import { Alert } from '@mui/material'
+
+const ErrorAlert = ({ message }: { message?: string }) => {
+  if (!message) return null
+  return (
+    <Alert severity="error" sx={{ mb: 2 }}>
+      {message}
+    </Alert>
+  )
+}
+
+export default ErrorAlert

--- a/frontend/src/components/LoadingState.tsx
+++ b/frontend/src/components/LoadingState.tsx
@@ -1,0 +1,12 @@
+import { CircularProgress, Stack, Typography } from '@mui/material'
+
+const LoadingState = ({ label = 'Loading...' }: { label?: string }) => {
+  return (
+    <Stack direction="row" spacing={2} alignItems="center" justifyContent="center" sx={{ py: 3 }}>
+      <CircularProgress size={24} />
+      <Typography>{label}</Typography>
+    </Stack>
+  )
+}
+
+export default LoadingState

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -1,7 +1,40 @@
-import { AppBar, Button, Stack, Toolbar, Typography } from '@mui/material'
-import { Link as RouterLink } from 'react-router-dom'
+import {
+  AppBar,
+  Avatar,
+  Box,
+  Button,
+  Divider,
+  IconButton,
+  Menu,
+  MenuItem,
+  Stack,
+  Toolbar,
+  Typography
+} from '@mui/material'
+import { useState } from 'react'
+import { Link as RouterLink, useNavigate } from 'react-router-dom'
+
+import { useAuth } from '../context/AuthContext'
 
 const NavBar = () => {
+  const { user, logout } = useAuth()
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const navigate = useNavigate()
+
+  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleMenuClose = () => setAnchorEl(null)
+
+  const handleLogout = () => {
+    logout()
+    handleMenuClose()
+    navigate('/login')
+  }
+
+  const isManager = user?.role === 'manager' || user?.role === 'admin'
+
   return (
     <AppBar position="static" color="primary">
       <Toolbar>
@@ -9,21 +42,51 @@ const NavBar = () => {
           Car Rental System
         </Typography>
         <Stack direction="row" spacing={2}>
-          <Button color="inherit" component={RouterLink} to="/login">
-            Login
-          </Button>
-          <Button color="inherit" component={RouterLink} to="/register">
-            Register
-          </Button>
           <Button color="inherit" component={RouterLink} to="/cars">
             Cars
           </Button>
-          <Button color="inherit" component={RouterLink} to="/bookings">
-            My Bookings
-          </Button>
-          <Button color="inherit" component={RouterLink} to="/admin">
-            Admin
-          </Button>
+          {user && (
+            <Button color="inherit" component={RouterLink} to="/bookings">
+              My Bookings
+            </Button>
+          )}
+          {isManager && (
+            <>
+              <Button color="inherit" component={RouterLink} to="/manage/cars">
+                Cars Admin
+              </Button>
+              <Button color="inherit" component={RouterLink} to="/manage/bookings">
+                Booking Queue
+              </Button>
+            </>
+          )}
+          {!user && (
+            <>
+              <Button color="inherit" component={RouterLink} to="/login">
+                Login
+              </Button>
+              <Button color="inherit" component={RouterLink} to="/register">
+                Register
+              </Button>
+            </>
+          )}
+          {user && (
+            <Box>
+              <IconButton color="inherit" onClick={handleMenuOpen}>
+                <Avatar sx={{ width: 28, height: 28 }}>
+                  {user.username.substring(0, 1).toUpperCase()}
+                </Avatar>
+              </IconButton>
+              <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleMenuClose}>
+                <MenuItem disabled>{user.email}</MenuItem>
+                <MenuItem disabled sx={{ textTransform: 'capitalize' }}>
+                  Role: {user.role}
+                </MenuItem>
+                <Divider />
+                <MenuItem onClick={handleLogout}>Logout</MenuItem>
+              </Menu>
+            </Box>
+          )}
         </Stack>
       </Toolbar>
     </AppBar>

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,35 @@
+import { CircularProgress, Container } from '@mui/material'
+import { Navigate, useLocation } from 'react-router-dom'
+
+import { useAuth } from '../context/AuthContext'
+import { UserRole } from '../types'
+
+interface ProtectedRouteProps {
+  children: JSX.Element
+  roles?: UserRole[]
+}
+
+const ProtectedRoute = ({ children, roles }: ProtectedRouteProps) => {
+  const { user, loading, hasRole } = useAuth()
+  const location = useLocation()
+
+  if (loading) {
+    return (
+      <Container sx={{ py: 4, display: 'flex', justifyContent: 'center' }}>
+        <CircularProgress />
+      </Container>
+    )
+  }
+
+  if (!user) {
+    return <Navigate to="/login" state={{ from: location }} replace />
+  }
+
+  if (!hasRole(roles)) {
+    return <Navigate to="/cars" replace />
+  }
+
+  return children
+}
+
+export default ProtectedRoute

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,116 @@
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from 'react'
+
+import { clearStoredTokens, getStoredTokens, setStoredTokens, subscribeToAuthChanges } from '../api/authStorage'
+import authService from '../services/authService'
+import { AuthTokens, User, UserRole } from '../types'
+
+interface AuthContextValue {
+  user: User | null
+  tokens: AuthTokens | null
+  loading: boolean
+  login: (credentials: { username: string; password: string }) => Promise<void>
+  register: (payload: RegisterPayload) => Promise<User>
+  logout: () => void
+  hasRole: (roles?: UserRole[]) => boolean
+  refreshProfile: () => Promise<void>
+}
+
+interface RegisterPayload {
+  username: string
+  email: string
+  password: string
+  full_name: string
+  phone: string
+  driver_license_no: string
+  address: string
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null)
+  const [tokens, setTokensState] = useState<AuthTokens | null>(getStoredTokens())
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const unsubscribe = subscribeToAuthChanges((newTokens) => {
+      setTokensState(newTokens)
+    })
+    return () => {
+      unsubscribe()
+    }
+  }, [])
+
+  useEffect(() => {
+    const bootstrap = async () => {
+      if (!tokens) {
+        setLoading(false)
+        return
+      }
+      try {
+        const profile = await authService.me()
+        setUser(profile)
+      } catch {
+        clearStoredTokens()
+        setUser(null)
+      } finally {
+        setLoading(false)
+      }
+    }
+    bootstrap()
+  }, [tokens])
+
+  const login = async (credentials: { username: string; password: string }) => {
+    const tokenResponse = await authService.login(credentials)
+    setStoredTokens(tokenResponse)
+    setTokensState(tokenResponse)
+    const profile = await authService.me()
+    setUser(profile)
+  }
+
+  const register = async (payload: RegisterPayload) => {
+    const created = await authService.register(payload)
+    return created
+  }
+
+  const logout = () => {
+    clearStoredTokens()
+    setTokensState(null)
+    setUser(null)
+  }
+
+  const refreshProfile = async () => {
+    if (!tokens) return
+    const profile = await authService.me()
+    setUser(profile)
+  }
+
+  const hasRole = (roles?: UserRole[]) => {
+    if (!roles || roles.length === 0) return !!user
+    return !!user && roles.includes(user.role)
+  }
+
+  const value = useMemo(
+    () => ({
+      user,
+      tokens,
+      loading,
+      login,
+      register,
+      logout,
+      hasRole,
+      refreshProfile
+    }),
+    [user, tokens, loading]
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 
 import App from './App'
+import { AuthProvider } from './context/AuthContext'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>
 )

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,15 +1,43 @@
-import { Container, Typography } from '@mui/material'
+import { Box, Card, CardActionArea, CardContent, Grid, Typography } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 
 const AdminPage = () => {
+  const cards = [
+    {
+      title: 'Manage cars',
+      description: 'Create, update, and retire vehicles from the fleet.',
+      to: '/manage/cars'
+    },
+    {
+      title: 'Booking queue',
+      description: 'Confirm, check-in, return, or cancel reservations.',
+      to: '/manage/bookings'
+    }
+  ]
+
   return (
-    <Container sx={{ py: 4 }}>
+    <Box sx={{ py: 4 }}>
       <Typography variant="h4" gutterBottom>
-        Admin Dashboard
+        Manager console
       </Typography>
-      <Typography variant="body1">
-        Administrative tools will be introduced once foundational services are implemented.
+      <Typography color="text.secondary" sx={{ mb: 2 }}>
+        Use the tools below to manage inventory and active reservations.
       </Typography>
-    </Container>
+      <Grid container spacing={2}>
+        {cards.map((card) => (
+          <Grid item xs={12} md={6} key={card.to}>
+            <Card variant="outlined">
+              <CardActionArea component={RouterLink} to={card.to}>
+                <CardContent>
+                  <Typography variant="h6">{card.title}</Typography>
+                  <Typography color="text.secondary">{card.description}</Typography>
+                </CardContent>
+              </CardActionArea>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
   )
 }
 

--- a/frontend/src/pages/BookingDetailPage.tsx
+++ b/frontend/src/pages/BookingDetailPage.tsx
@@ -1,0 +1,387 @@
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  Grid,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useParams } from 'react-router-dom'
+
+import ErrorAlert from '../components/ErrorAlert'
+import LoadingState from '../components/LoadingState'
+import { useAuth } from '../context/AuthContext'
+import bookingService from '../services/bookingService'
+import { Booking, Fine } from '../types'
+
+interface FineForm {
+  type: Fine['type']
+  amount: string
+  notes?: string
+}
+
+interface DepositForm {
+  amount: string
+}
+
+const BookingDetailPage = () => {
+  const { bookingId } = useParams()
+  const { user } = useAuth()
+  const [booking, setBooking] = useState<Booking | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [message, setMessage] = useState('')
+
+  const fineForm = useForm<FineForm>({
+    defaultValues: { type: 'other', amount: '', notes: '' }
+  })
+
+  const depositForm = useForm<DepositForm>({
+    defaultValues: { amount: '250.00' }
+  })
+
+  const loadBooking = async () => {
+    if (!bookingId) return
+    setLoading(true)
+    setError('')
+    try {
+      const data = await bookingService.getBooking(bookingId)
+      setBooking(data)
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Unable to load booking.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadBooking()
+  }, [bookingId])
+
+  const handleAction = async (fn: () => Promise<any>, successMessage: string) => {
+    setError('')
+    setMessage('')
+    try {
+      await fn()
+      setMessage(successMessage)
+      await loadBooking()
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Action failed.')
+    }
+  }
+
+  const isManager = user?.role === 'manager' || user?.role === 'admin'
+
+  if (loading) {
+    return <LoadingState label="Loading booking..." />
+  }
+
+  if (!booking) {
+    return <ErrorAlert message={error || 'Booking not found.'} />
+  }
+
+  return (
+    <Box sx={{ py: 4 }}>
+      <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 2 }}>
+        <Typography variant="h4">
+          Booking for {booking.car.make} {booking.car.model}
+        </Typography>
+        <Chip label={booking.status} sx={{ textTransform: 'capitalize' }} />
+      </Stack>
+      <Typography color="text.secondary" sx={{ mb: 2 }}>
+        {booking.start_date} → {booking.end_date}
+      </Typography>
+      <ErrorAlert message={error} />
+      {message && (
+        <Card variant="outlined" sx={{ borderColor: 'success.main', mb: 2 }}>
+          <CardContent>
+            <Typography color="success.main">{message}</Typography>
+          </CardContent>
+        </Card>
+      )}
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={8}>
+          <Card variant="outlined" sx={{ mb: 2 }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Booking details
+              </Typography>
+              <Typography color="text.secondary">
+                Vehicle: {booking.car.make} {booking.car.model} ({booking.car.year})
+              </Typography>
+              <Typography color="text.secondary">VIN: {booking.car.vin}</Typography>
+              <Typography color="text.secondary" sx={{ mt: 1 }}>
+                Created {new Date(booking.created_at).toLocaleString()}
+              </Typography>
+              <Typography color="text.secondary">
+                Last updated {new Date(booking.updated_at).toLocaleString()}
+              </Typography>
+              <Divider sx={{ my: 2 }} />
+              <Stack direction="row" spacing={1}>
+                <Button
+                  variant="outlined"
+                  color="error"
+                  onClick={() =>
+                    handleAction(() => bookingService.cancelBooking(booking.id), 'Booking canceled.')
+                  }
+                  disabled={booking.status === 'canceled' || booking.status === 'completed'}
+                >
+                  Cancel booking
+                </Button>
+                {isManager && (
+                  <>
+                    <Button
+                      variant="outlined"
+                      onClick={() =>
+                        handleAction(
+                          () => bookingService.confirmBooking(booking.id),
+                          'Booking confirmed.'
+                        )
+                      }
+                      disabled={booking.status !== 'pending'}
+                    >
+                      Confirm
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      onClick={() =>
+                        handleAction(
+                          () => bookingService.checkinBooking(booking.id),
+                          'Check-in recorded.'
+                        )
+                      }
+                      disabled={booking.status !== 'confirmed'}
+                    >
+                      Check-in
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      onClick={() =>
+                        handleAction(
+                          () => bookingService.returnBooking(booking.id),
+                          'Vehicle returned.'
+                        )
+                      }
+                      disabled={booking.status !== 'active'}
+                    >
+                      Return
+                    </Button>
+                  </>
+                )}
+              </Stack>
+            </CardContent>
+          </Card>
+
+          <Card variant="outlined" sx={{ mb: 2 }}>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Typography variant="h6">Invoice</Typography>
+                {booking.invoice?.paid_at ? (
+                  <Chip label="Paid" color="success" size="small" />
+                ) : (
+                  booking.invoice && (
+                    <Chip label="Unpaid" color="warning" size="small" variant="outlined" />
+                  )
+                )}
+              </Stack>
+              {booking.invoice ? (
+                <Box sx={{ mt: 2 }}>
+                  {booking.invoice.breakdown.map((item, idx) => (
+                    <Stack
+                      key={idx}
+                      direction="row"
+                      justifyContent="space-between"
+                      sx={{ mb: 1 }}
+                    >
+                      <Typography color="text.secondary">{item.label}</Typography>
+                      <Typography>${item.amount}</Typography>
+                    </Stack>
+                  ))}
+                  <Stack direction="row" justifyContent="space-between" sx={{ mt: 1 }}>
+                    <Typography fontWeight="bold">Total</Typography>
+                    <Typography fontWeight="bold">${booking.invoice.total}</Typography>
+                  </Stack>
+                  {!booking.invoice.paid_at && (
+                    <Button
+                      sx={{ mt: 2 }}
+                      variant="contained"
+                      onClick={() =>
+                        handleAction(
+                          () => bookingService.payInvoice(booking.id),
+                          'Invoice marked as paid.'
+                        )
+                      }
+                    >
+                      Pay invoice (mock)
+                    </Button>
+                  )}
+                </Box>
+              ) : (
+                <Typography color="text.secondary" sx={{ mt: 1 }}>
+                  Invoice will be generated after return.
+                </Typography>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card variant="outlined">
+            <CardContent>
+              <Typography variant="h6">Fines</Typography>
+              {booking.fines.length === 0 ? (
+                <Typography color="text.secondary" sx={{ mt: 1 }}>
+                  No fines assessed.
+                </Typography>
+              ) : (
+                booking.fines.map((fine) => (
+                  <Card key={fine.id} variant="outlined" sx={{ mt: 1 }}>
+                    <CardContent>
+                      <Stack direction="row" justifyContent="space-between">
+                        <Typography sx={{ textTransform: 'capitalize' }}>
+                          {fine.type.replace('_', ' ')}
+                        </Typography>
+                        <Typography>${fine.amount}</Typography>
+                      </Stack>
+                      <Typography color="text.secondary">
+                        {new Date(fine.assessed_at).toLocaleString()}
+                      </Typography>
+                      {fine.notes && <Typography sx={{ mt: 1 }}>{fine.notes}</Typography>}
+                    </CardContent>
+                  </Card>
+                ))
+              )}
+              {isManager && (
+                <Box sx={{ mt: 2 }}>
+                  <Typography variant="subtitle1" gutterBottom>
+                    Add fine
+                  </Typography>
+                  <Stack
+                    component="form"
+                    spacing={2}
+                    onSubmit={fineForm.handleSubmit((data) =>
+                      handleAction(
+                        () =>
+                          bookingService.addFine(booking.id, {
+                            type: data.type,
+                            amount: data.amount,
+                            notes: data.notes
+                          }),
+                        'Fine added.'
+                      )
+                    )}
+                  >
+                    <TextField label="Type" {...fineForm.register('type')} />
+                    <TextField
+                      label="Amount"
+                      type="number"
+                      {...fineForm.register('amount', { required: 'Amount is required' })}
+                      error={Boolean(fineForm.formState.errors.amount)}
+                      helperText={fineForm.formState.errors.amount?.message}
+                    />
+                    <TextField label="Notes" multiline minRows={2} {...fineForm.register('notes')} />
+                    <Button type="submit" variant="outlined">
+                      Apply fine
+                    </Button>
+                  </Stack>
+                </Box>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12} md={4}>
+          <Card variant="outlined">
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Typography variant="h6">Deposit</Typography>
+                {booking.deposit ? (
+                  <Chip
+                    label={booking.deposit.status}
+                    size="small"
+                    sx={{ textTransform: 'capitalize' }}
+                  />
+                ) : (
+                  <Chip label="Not held" size="small" />
+                )}
+              </Stack>
+              {booking.deposit ? (
+                <Box sx={{ mt: 2 }}>
+                  <Typography color="text.secondary">
+                    Amount: ${booking.deposit.amount}
+                  </Typography>
+                  <Typography color="text.secondary">
+                    Updated: {new Date(booking.deposit.updated_at).toLocaleString()}
+                  </Typography>
+                  {isManager && (
+                    <Stack spacing={1} sx={{ mt: 2 }}>
+                      <Button
+                        variant="outlined"
+                        onClick={() =>
+                          handleAction(
+                            () => bookingService.releaseDeposit(booking.id),
+                            'Deposit released.'
+                          )
+                        }
+                      >
+                        Release deposit
+                      </Button>
+                      <Button
+                        variant="outlined"
+                        color="error"
+                        onClick={() =>
+                          handleAction(
+                            () => bookingService.forfeitDeposit(booking.id),
+                            'Deposit forfeited.'
+                          )
+                        }
+                      >
+                        Forfeit deposit
+                      </Button>
+                    </Stack>
+                  )}
+                </Box>
+              ) : (
+                <Typography color="text.secondary" sx={{ mt: 1 }}>
+                  No deposit has been captured for this booking.
+                </Typography>
+              )}
+              {isManager && (
+                <Box sx={{ mt: 2 }}>
+                  <Typography variant="subtitle1">Hold deposit</Typography>
+                  <Stack
+                    component="form"
+                    spacing={2}
+                    onSubmit={depositForm.handleSubmit((data) =>
+                      handleAction(
+                        () => bookingService.holdDeposit(booking.id, data.amount),
+                        'Deposit held.'
+                      )
+                    )}
+                  >
+                    <TextField
+                      label="Amount"
+                      type="number"
+                      {...depositForm.register('amount', { required: 'Amount is required' })}
+                      error={Boolean(depositForm.formState.errors.amount)}
+                      helperText={depositForm.formState.errors.amount?.message}
+                    />
+                    <Button type="submit" variant="outlined">
+                      Hold deposit
+                    </Button>
+                  </Stack>
+                </Box>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  )
+}
+
+export default BookingDetailPage

--- a/frontend/src/pages/CarDetailPage.tsx
+++ b/frontend/src/pages/CarDetailPage.tsx
@@ -1,0 +1,247 @@
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Divider,
+  Grid,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useNavigate, useParams } from 'react-router-dom'
+
+import ErrorAlert from '../components/ErrorAlert'
+import LoadingState from '../components/LoadingState'
+import { useAuth } from '../context/AuthContext'
+import bookingService from '../services/bookingService'
+import carService from '../services/carService'
+import pricingService from '../services/pricingService'
+import { Car, QuoteResponse } from '../types'
+
+interface QuoteForm {
+  start_date: string
+  end_date: string
+}
+
+const CarDetailPage = () => {
+  const { carId } = useParams()
+  const navigate = useNavigate()
+  const { user } = useAuth()
+  const [car, setCar] = useState<Car | null>(null)
+  const [quote, setQuote] = useState<QuoteResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<QuoteForm>({
+    defaultValues: {
+      start_date: '',
+      end_date: ''
+    }
+  })
+
+  useEffect(() => {
+    const loadCar = async () => {
+      if (!carId) return
+      setLoading(true)
+      setError('')
+      try {
+        const data = await carService.getCar(carId)
+        setCar(data)
+      } catch (err: any) {
+        setError(err?.response?.data?.detail ?? 'Unable to load car details.')
+      } finally {
+        setLoading(false)
+      }
+    }
+    loadCar()
+  }, [carId])
+
+  const onQuote = async (formData: QuoteForm) => {
+    if (!carId) return
+    setSuccess('')
+    setError('')
+    try {
+      const quoteResponse = await pricingService.quote(
+        carId,
+        formData.start_date,
+        formData.end_date
+      )
+      setQuote(quoteResponse)
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Unable to retrieve quote.')
+    }
+  }
+
+  const onCreateBooking = async (formData: QuoteForm) => {
+    if (!carId) return
+    if (!user) {
+      setError('Please login to create a booking.')
+      return
+    }
+    setError('')
+    setSuccess('')
+    try {
+      const booking = await bookingService.createBooking({
+        car_id: carId,
+        start_date: formData.start_date,
+        end_date: formData.end_date
+      })
+      setSuccess('Booking created successfully.')
+      navigate(`/bookings/${booking.id}`)
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Unable to create booking.')
+    }
+  }
+
+  if (loading) {
+    return <LoadingState label="Loading car..." />
+  }
+
+  if (!car) {
+    return <ErrorAlert message={error || 'Car not found.'} />
+  }
+
+  return (
+    <Box sx={{ py: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        {car.make} {car.model} ({car.year})
+      </Typography>
+      <ErrorAlert message={error} />
+      {success && (
+        <Card sx={{ mb: 2, borderColor: 'success.main' }} variant="outlined">
+          <CardContent>
+            <Typography color="success.main">{success}</Typography>
+          </CardContent>
+        </Card>
+      )}
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={7}>
+          <Card variant="outlined">
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Vehicle details
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={6}>
+                  <Typography color="text.secondary">Make</Typography>
+                  <Typography>{car.make}</Typography>
+                </Grid>
+                <Grid item xs={6}>
+                  <Typography color="text.secondary">Model</Typography>
+                  <Typography>{car.model}</Typography>
+                </Grid>
+                <Grid item xs={6}>
+                  <Typography color="text.secondary">Year</Typography>
+                  <Typography>{car.year}</Typography>
+                </Grid>
+                <Grid item xs={6}>
+                  <Typography color="text.secondary">VIN</Typography>
+                  <Typography>{car.vin}</Typography>
+                </Grid>
+                <Grid item xs={6}>
+                  <Typography color="text.secondary">Type</Typography>
+                  <Typography sx={{ textTransform: 'capitalize' }}>{car.type}</Typography>
+                </Grid>
+                <Grid item xs={6}>
+                  <Typography color="text.secondary">Status</Typography>
+                  <Typography sx={{ textTransform: 'capitalize' }}>{car.status}</Typography>
+                </Grid>
+                <Grid item xs={6}>
+                  <Typography color="text.secondary">Base Price / day</Typography>
+                  <Typography>${car.base_price_per_day}</Typography>
+                </Grid>
+                <Grid item xs={6}>
+                  <Typography color="text.secondary">Mileage</Typography>
+                  <Typography>{car.mileage.toLocaleString()} km</Typography>
+                </Grid>
+                <Grid item xs={6}>
+                  <Typography color="text.secondary">Last service</Typography>
+                  <Typography>{car.last_service_at ?? 'Not recorded'}</Typography>
+                </Grid>
+              </Grid>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} md={5}>
+          <Card variant="outlined">
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Get quote & book
+              </Typography>
+              {!user && (
+                <Typography color="text.secondary" sx={{ mb: 2 }}>
+                  You can browse publicly. Sign in to complete a booking.
+                </Typography>
+              )}
+              <Stack
+                component="form"
+                spacing={2}
+                onSubmit={handleSubmit((data) => {
+                  onQuote(data)
+                })}
+              >
+                <TextField
+                  label="Start date"
+                  type="date"
+                  InputLabelProps={{ shrink: true }}
+                  {...register('start_date', { required: 'Start date is required' })}
+                  error={Boolean(errors.start_date)}
+                  helperText={errors.start_date?.message}
+                />
+                <TextField
+                  label="End date"
+                  type="date"
+                  InputLabelProps={{ shrink: true }}
+                  {...register('end_date', { required: 'End date is required' })}
+                  error={Boolean(errors.end_date)}
+                  helperText={errors.end_date?.message}
+                />
+                <Stack direction="row" spacing={1}>
+                  <Button type="submit" variant="contained">
+                    Get quote
+                  </Button>
+                  <Button variant="outlined" onClick={handleSubmit(onCreateBooking)} disabled={!user}>
+                    Create booking
+                  </Button>
+                </Stack>
+              </Stack>
+              {quote && (
+                <Box sx={{ mt: 3 }}>
+                  <Divider sx={{ mb: 2 }} />
+                  <Typography variant="subtitle1" gutterBottom>
+                    Quote
+                  </Typography>
+                  {quote.breakdown.map((item, idx) => (
+                    <Stack
+                      key={idx}
+                      direction="row"
+                      justifyContent="space-between"
+                      sx={{ mb: 1 }}
+                    >
+                      <Typography color="text.secondary">{item.label}</Typography>
+                      <Typography>${item.amount}</Typography>
+                    </Stack>
+                  ))}
+                  <Stack direction="row" justifyContent="space-between" sx={{ mt: 1 }}>
+                    <Typography variant="h6">Total</Typography>
+                    <Typography variant="h6">${quote.total}</Typography>
+                  </Stack>
+                </Box>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  )
+}
+
+export default CarDetailPage

--- a/frontend/src/pages/CarsPage.tsx
+++ b/frontend/src/pages/CarsPage.tsx
@@ -1,15 +1,136 @@
-import { Container, Typography } from '@mui/material'
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Chip,
+  Grid,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { Link as RouterLink } from 'react-router-dom'
+
+import ErrorAlert from '../components/ErrorAlert'
+import LoadingState from '../components/LoadingState'
+import carService, { CarFilters } from '../services/carService'
+import { Car } from '../types'
 
 const CarsPage = () => {
+  const [cars, setCars] = useState<Car[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const { register, handleSubmit, reset } = useForm<CarFilters>({
+    defaultValues: { make: '', model: '', search: '' }
+  })
+
+  const fetchCars = async (filters: CarFilters = {}) => {
+    setLoading(true)
+    setError('')
+    try {
+      const response = await carService.listCars(filters)
+      setCars(response.results)
+    } catch (err: any) {
+      setError(
+        err?.response?.status === 401
+          ? 'Login is required to browse inventory.'
+          : err?.response?.data?.detail ?? 'Unable to load cars.'
+      )
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchCars()
+  }, [])
+
+  const onFilter = (values: CarFilters) => {
+    fetchCars(values)
+  }
+
+  const clearFilters = () => {
+    reset({ make: '', model: '', type: '', status: '', year_min: '', year_max: '', search: '' })
+    fetchCars()
+  }
+
   return (
-    <Container sx={{ py: 4 }}>
+    <Box sx={{ py: 4 }}>
       <Typography variant="h4" gutterBottom>
         Cars
       </Typography>
-      <Typography variant="body1">
-        Vehicle browsing and filters will appear here once the inventory service is available.
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
+        Browse available vehicles and filter by make, model, or status.
       </Typography>
-    </Container>
+      <ErrorAlert message={error} />
+      <Card variant="outlined" sx={{ mb: 3 }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            Filters
+          </Typography>
+          <Stack
+            component="form"
+            spacing={2}
+            direction={{ xs: 'column', md: 'row' }}
+            alignItems="flex-end"
+            onSubmit={handleSubmit(onFilter)}
+          >
+            <TextField label="Make" {...register('make')} />
+            <TextField label="Model" {...register('model')} />
+            <TextField label="Type" {...register('type')} />
+            <TextField label="Status" {...register('status')} />
+            <TextField label="Year min" type="number" {...register('year_min')} />
+            <TextField label="Year max" type="number" {...register('year_max')} />
+            <TextField label="Search" {...register('search')} />
+            <Stack direction="row" spacing={1}>
+              <Button type="submit" variant="contained">
+                Apply
+              </Button>
+              <Button variant="text" onClick={clearFilters}>
+                Reset
+              </Button>
+            </Stack>
+          </Stack>
+        </CardContent>
+      </Card>
+      {loading ? (
+        <LoadingState label="Loading cars..." />
+      ) : (
+        <Grid container spacing={2}>
+          {cars.map((car) => (
+            <Grid item xs={12} md={6} lg={4} key={car.id}>
+              <Card variant="outlined" sx={{ height: '100%' }}>
+                <CardContent>
+                  <Typography variant="h6" gutterBottom>
+                    {car.make} {car.model} ({car.year})
+                  </Typography>
+                  <Stack spacing={1}>
+                    <Typography color="text.secondary">Type: {car.type}</Typography>
+                    <Typography color="text.secondary">
+                      Rate: ${car.base_price_per_day} / day
+                    </Typography>
+                    <Typography color="text.secondary">Mileage: {car.mileage} km</Typography>
+                    <Chip label={car.status} size="small" sx={{ textTransform: 'capitalize' }} />
+                  </Stack>
+                </CardContent>
+                <CardActions>
+                  <Button component={RouterLink} to={`/cars/${car.id}`} size="small">
+                    View details
+                  </Button>
+                </CardActions>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      )}
+      {!loading && !error && cars.length === 0 && (
+        <Typography sx={{ mt: 2 }}>No cars match the selected filters.</Typography>
+      )}
+    </Box>
   )
 }
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,13 +1,83 @@
-import { Container, Typography } from '@mui/material'
+import { Box, Button, Card, CardContent, Stack, TextField, Typography } from '@mui/material'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useLocation, useNavigate, Link as RouterLink } from 'react-router-dom'
+
+import ErrorAlert from '../components/ErrorAlert'
+import { useAuth } from '../context/AuthContext'
+
+interface LoginForm {
+  username: string
+  password: string
+}
 
 const LoginPage = () => {
+  const { login } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [error, setError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const from = (location.state as any)?.from?.pathname || '/cars'
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<LoginForm>({
+    defaultValues: { username: '', password: '' }
+  })
+
+  const onSubmit = async (data: LoginForm) => {
+    setError('')
+    setSubmitting(true)
+    try {
+      await login(data)
+      navigate(from, { replace: true })
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Unable to sign in.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
   return (
-    <Container sx={{ py: 4 }}>
-      <Typography variant="h4" gutterBottom>
-        Login
-      </Typography>
-      <Typography variant="body1">Authentication flows will be added in later milestones.</Typography>
-    </Container>
+    <Box sx={{ py: 4, display: 'flex', justifyContent: 'center' }}>
+      <Card sx={{ maxWidth: 480, width: '100%' }} variant="outlined">
+        <CardContent>
+          <Typography variant="h4" gutterBottom>
+            Login
+          </Typography>
+          <Typography color="text.secondary" sx={{ mb: 2 }}>
+            Sign in to manage bookings and reservations.
+          </Typography>
+          <ErrorAlert message={error} />
+          <Stack component="form" spacing={2} onSubmit={handleSubmit(onSubmit)}>
+            <TextField
+              label="Username"
+              {...register('username', { required: 'Username is required' })}
+              error={Boolean(errors.username)}
+              helperText={errors.username?.message}
+            />
+            <TextField
+              label="Password"
+              type="password"
+              {...register('password', { required: 'Password is required' })}
+              error={Boolean(errors.password)}
+              helperText={errors.password?.message}
+            />
+            <Button type="submit" variant="contained" disabled={submitting}>
+              {submitting ? 'Signing in...' : 'Login'}
+            </Button>
+          </Stack>
+          <Typography sx={{ mt: 2 }}>
+            No account?{' '}
+            <RouterLink to="/register" style={{ textDecoration: 'none' }}>
+              Register
+            </RouterLink>
+          </Typography>
+        </CardContent>
+      </Card>
+    </Box>
   )
 }
 

--- a/frontend/src/pages/ManageBookingsPage.tsx
+++ b/frontend/src/pages/ManageBookingsPage.tsx
@@ -1,0 +1,153 @@
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  Stack,
+  Typography
+} from '@mui/material'
+import { useEffect, useState } from 'react'
+import { Link as RouterLink } from 'react-router-dom'
+
+import ErrorAlert from '../components/ErrorAlert'
+import LoadingState from '../components/LoadingState'
+import bookingService from '../services/bookingService'
+import { Booking } from '../types'
+
+const ManageBookingsPage = () => {
+  const [bookings, setBookings] = useState<Booking[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+
+  const loadBookings = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const response = await bookingService.listBookings()
+      setBookings(response.results)
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Unable to load bookings.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadBookings()
+  }, [])
+
+  const handleAction = async (id: string, action: 'confirm' | 'checkin' | 'return' | 'cancel') => {
+    setError('')
+    setSuccess('')
+    try {
+      const updated =
+        action === 'confirm'
+          ? await bookingService.confirmBooking(id)
+          : action === 'checkin'
+            ? await bookingService.checkinBooking(id)
+            : action === 'return'
+              ? await bookingService.returnBooking(id)
+              : await bookingService.cancelBooking(id)
+      setBookings((prev) => prev.map((b) => (b.id === id ? updated : b)))
+      setSuccess(`Booking ${action}ed.`)
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Action failed.')
+    }
+  }
+
+  return (
+    <Box sx={{ py: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Booking queue
+      </Typography>
+      <Typography color="text.secondary" sx={{ mb: 2 }}>
+        Manage confirmations, check-ins, returns, and cancellations.
+      </Typography>
+      <ErrorAlert message={error} />
+      {success && (
+        <Card variant="outlined" sx={{ mb: 2, borderColor: 'success.main' }}>
+          <CardContent>
+            <Typography color="success.main">{success}</Typography>
+          </CardContent>
+        </Card>
+      )}
+      {loading ? (
+        <LoadingState label="Loading bookings..." />
+      ) : (
+        <Grid container spacing={2}>
+          {bookings.map((booking) => (
+            <Grid item xs={12} key={booking.id}>
+              <Card variant="outlined">
+                <CardContent>
+                  <Stack
+                    direction={{ xs: 'column', md: 'row' }}
+                    justifyContent="space-between"
+                    alignItems={{ xs: 'flex-start', md: 'center' }}
+                    spacing={1}
+                  >
+                    <Box>
+                      <Typography variant="h6">
+                        {booking.car.make} {booking.car.model} ({booking.car.year})
+                      </Typography>
+                      <Typography color="text.secondary">
+                        {booking.start_date} → {booking.end_date}
+                      </Typography>
+                      <Typography color="text.secondary">Status: {booking.status}</Typography>
+                    </Box>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Chip label={booking.status} size="small" sx={{ textTransform: 'capitalize' }} />
+                      <Button component={RouterLink} to={`/manage/bookings/${booking.id}`} size="small">
+                        Detail
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => handleAction(booking.id, 'confirm')}
+                        disabled={booking.status !== 'pending'}
+                      >
+                        Confirm
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => handleAction(booking.id, 'checkin')}
+                        disabled={booking.status !== 'confirmed'}
+                      >
+                        Check-in
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => handleAction(booking.id, 'return')}
+                        disabled={booking.status !== 'active'}
+                      >
+                        Return
+                      </Button>
+                      <Button
+                        size="small"
+                        color="error"
+                        variant="outlined"
+                        onClick={() => handleAction(booking.id, 'cancel')}
+                        disabled={booking.status === 'canceled' || booking.status === 'completed'}
+                      >
+                        Cancel
+                      </Button>
+                    </Stack>
+                  </Stack>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      )}
+      {!loading && !error && bookings.length === 0 && (
+        <Typography sx={{ mt: 2 }}>No bookings in the queue.</Typography>
+      )}
+    </Box>
+  )
+}
+
+export default ManageBookingsPage

--- a/frontend/src/pages/ManageCarsPage.tsx
+++ b/frontend/src/pages/ManageCarsPage.tsx
@@ -1,0 +1,249 @@
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+import ErrorAlert from '../components/ErrorAlert'
+import LoadingState from '../components/LoadingState'
+import carService from '../services/carService'
+import { Car } from '../types'
+
+type CarFormValues = Omit<Car, 'id'>
+
+const ManageCarsPage = () => {
+  const [cars, setCars] = useState<Car[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [editingCar, setEditingCar] = useState<Car | null>(null)
+  const [success, setSuccess] = useState('')
+
+  const createForm = useForm<CarFormValues>({
+    defaultValues: {
+      make: '',
+      model: '',
+      year: new Date().getFullYear(),
+      vin: '',
+      type: '',
+      base_price_per_day: '0',
+      status: 'available',
+      mileage: 0,
+      last_service_at: ''
+    }
+  })
+
+  const editForm = useForm<CarFormValues>()
+
+  const loadCars = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const response = await carService.listCars()
+      setCars(response.results)
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Unable to load cars.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadCars()
+  }, [])
+
+  const handleCreate = async (values: CarFormValues) => {
+    setError('')
+    setSuccess('')
+    try {
+      await carService.createCar(values)
+      setSuccess('Car created.')
+      createForm.reset()
+      loadCars()
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Unable to create car.')
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    setError('')
+    try {
+      await carService.deleteCar(id)
+      setSuccess('Car removed.')
+      loadCars()
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Unable to delete car.')
+    }
+  }
+
+  const handleEditSubmit = async (values: CarFormValues) => {
+    if (!editingCar) return
+    setError('')
+    setSuccess('')
+    try {
+      await carService.updateCar(editingCar.id, values)
+      setSuccess('Car updated.')
+      setEditingCar(null)
+      loadCars()
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Unable to update car.')
+    }
+  }
+
+  const openEdit = (car: Car) => {
+    setEditingCar(car)
+    editForm.reset({ ...car, last_service_at: car.last_service_at ?? '' })
+  }
+
+  return (
+    <Box sx={{ py: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Manage cars
+      </Typography>
+      <Typography color="text.secondary" sx={{ mb: 2 }}>
+        Create, update, or retire vehicles from the fleet.
+      </Typography>
+      <ErrorAlert message={error} />
+      {success && (
+        <Card variant="outlined" sx={{ mb: 2, borderColor: 'success.main' }}>
+          <CardContent>
+            <Typography color="success.main">{success}</Typography>
+          </CardContent>
+        </Card>
+      )}
+      <Card variant="outlined" sx={{ mb: 3 }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            Add car
+          </Typography>
+          <Stack
+            component="form"
+            spacing={2}
+            onSubmit={createForm.handleSubmit(handleCreate)}
+            direction={{ xs: 'column', md: 'row' }}
+            flexWrap="wrap"
+          >
+            <TextField
+              label="Make"
+              {...createForm.register('make', { required: 'Required' })}
+              error={Boolean(createForm.formState.errors.make)}
+              helperText={createForm.formState.errors.make?.message}
+            />
+            <TextField
+              label="Model"
+              {...createForm.register('model', { required: 'Required' })}
+              error={Boolean(createForm.formState.errors.model)}
+              helperText={createForm.formState.errors.model?.message}
+            />
+            <TextField label="Year" type="number" {...createForm.register('year', { valueAsNumber: true })} />
+            <TextField label="VIN" {...createForm.register('vin', { required: 'Required' })} />
+            <TextField label="Type" {...createForm.register('type', { required: 'Required' })} />
+            <TextField
+              label="Base price per day"
+              type="number"
+              {...createForm.register('base_price_per_day', { required: 'Required' })}
+            />
+            <TextField label="Status" {...createForm.register('status')} />
+            <TextField label="Mileage" type="number" {...createForm.register('mileage', { valueAsNumber: true })} />
+            <TextField
+              label="Last service at"
+              type="date"
+              InputLabelProps={{ shrink: true }}
+              {...createForm.register('last_service_at')}
+            />
+            <Button type="submit" variant="contained">
+              Add car
+            </Button>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      {loading ? (
+        <LoadingState label="Loading cars..." />
+      ) : (
+        <Grid container spacing={2}>
+          {cars.map((car) => (
+            <Grid item xs={12} md={6} key={car.id}>
+              <Card variant="outlined">
+                <CardContent>
+                  <Typography variant="h6">
+                    {car.make} {car.model} ({car.year})
+                  </Typography>
+                  <Typography color="text.secondary">VIN: {car.vin}</Typography>
+                  <Typography color="text.secondary">Type: {car.type}</Typography>
+                  <Typography color="text.secondary">Status: {car.status}</Typography>
+                  <Typography color="text.secondary">
+                    Rate: ${car.base_price_per_day} / day
+                  </Typography>
+                </CardContent>
+                <CardActions>
+                  <Button size="small" onClick={() => openEdit(car)}>
+                    Edit
+                  </Button>
+                  <Button size="small" color="error" onClick={() => handleDelete(car.id)}>
+                    Delete
+                  </Button>
+                </CardActions>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      )}
+
+      <Dialog open={Boolean(editingCar)} onClose={() => setEditingCar(null)} maxWidth="md" fullWidth>
+        <DialogTitle>Edit car</DialogTitle>
+        <DialogContent>
+          <Stack component="form" spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Make"
+              {...editForm.register('make', { required: 'Required' })}
+              error={Boolean(editForm.formState.errors.make)}
+              helperText={editForm.formState.errors.make?.message}
+            />
+            <TextField
+              label="Model"
+              {...editForm.register('model', { required: 'Required' })}
+              error={Boolean(editForm.formState.errors.model)}
+              helperText={editForm.formState.errors.model?.message}
+            />
+            <TextField label="Year" type="number" {...editForm.register('year', { valueAsNumber: true })} />
+            <TextField label="VIN" {...editForm.register('vin', { required: 'Required' })} />
+            <TextField label="Type" {...editForm.register('type', { required: 'Required' })} />
+            <TextField
+              label="Base price per day"
+              type="number"
+              {...editForm.register('base_price_per_day', { required: 'Required' })}
+            />
+            <TextField label="Status" {...editForm.register('status')} />
+            <TextField label="Mileage" type="number" {...editForm.register('mileage', { valueAsNumber: true })} />
+            <TextField
+              label="Last service at"
+              type="date"
+              InputLabelProps={{ shrink: true }}
+              {...editForm.register('last_service_at')}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditingCar(null)}>Cancel</Button>
+          <Button onClick={editForm.handleSubmit(handleEditSubmit)} variant="contained">
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  )
+}
+
+export default ManageCarsPage

--- a/frontend/src/pages/MyBookingsPage.tsx
+++ b/frontend/src/pages/MyBookingsPage.tsx
@@ -1,13 +1,88 @@
-import { Container, Typography } from '@mui/material'
+import {
+  Box,
+  Card,
+  CardActionArea,
+  CardContent,
+  Chip,
+  Grid,
+  Stack,
+  Typography
+} from '@mui/material'
+import { useEffect, useState } from 'react'
+import { Link as RouterLink } from 'react-router-dom'
+
+import ErrorAlert from '../components/ErrorAlert'
+import LoadingState from '../components/LoadingState'
+import bookingService from '../services/bookingService'
+import { Booking } from '../types'
 
 const MyBookingsPage = () => {
+  const [bookings, setBookings] = useState<Booking[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const loadBookings = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const response = await bookingService.listBookings()
+      setBookings(response.results)
+    } catch (err: any) {
+      setError(err?.response?.data?.detail ?? 'Unable to load bookings.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadBookings()
+  }, [])
+
   return (
-    <Container sx={{ py: 4 }}>
+    <Box sx={{ py: 4 }}>
       <Typography variant="h4" gutterBottom>
         My Bookings
       </Typography>
-      <Typography variant="body1">Booking history and actions will be added in the booking service milestone.</Typography>
-    </Container>
+      <Typography color="text.secondary" sx={{ mb: 2 }}>
+        Track reservation status, deposits, and invoices.
+      </Typography>
+      <ErrorAlert message={error} />
+      {loading ? (
+        <LoadingState label="Loading bookings..." />
+      ) : (
+        <Grid container spacing={2}>
+          {bookings.map((booking) => (
+            <Grid item xs={12} md={6} key={booking.id}>
+              <Card variant="outlined">
+                <CardActionArea component={RouterLink} to={`/bookings/${booking.id}`}>
+                  <CardContent>
+                    <Stack direction="row" justifyContent="space-between" alignItems="center">
+                      <Typography variant="h6">
+                        {booking.car.make} {booking.car.model}
+                      </Typography>
+                      <Chip
+                        label={booking.status}
+                        size="small"
+                        sx={{ textTransform: 'capitalize' }}
+                      />
+                    </Stack>
+                    <Typography color="text.secondary" sx={{ mt: 1 }}>
+                      {booking.start_date} → {booking.end_date}
+                    </Typography>
+                    <Typography color="text.secondary">
+                      Updated {new Date(booking.updated_at).toLocaleString()}
+                    </Typography>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      )}
+      {!loading && !error && bookings.length === 0 && (
+        <Typography sx={{ mt: 2 }}>No bookings yet. Reserve a car to get started.</Typography>
+      )}
+    </Box>
   )
 }
 

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,13 +1,171 @@
-import { Container, Typography } from '@mui/material'
+import { Box, Button, Card, CardContent, Grid, Stack, TextField, Typography } from '@mui/material'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { Link as RouterLink, useNavigate } from 'react-router-dom'
+
+import ErrorAlert from '../components/ErrorAlert'
+import { useAuth } from '../context/AuthContext'
+
+interface RegisterForm {
+  username: string
+  email: string
+  password: string
+  full_name: string
+  phone: string
+  driver_license_no: string
+  address: string
+}
 
 const RegisterPage = () => {
+  const { register: registerUser } = useAuth()
+  const navigate = useNavigate()
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<RegisterForm>({
+    defaultValues: {
+      username: '',
+      email: '',
+      password: '',
+      full_name: '',
+      phone: '',
+      driver_license_no: '',
+      address: ''
+    }
+  })
+
+  const onSubmit = async (data: RegisterForm) => {
+    setError('')
+    setSubmitting(true)
+    try {
+      await registerUser(data)
+      setSuccess('Account created. Please login to continue.')
+      setTimeout(() => navigate('/login'), 800)
+    } catch (err: any) {
+      const resp = err?.response?.data
+      const detail = resp?.detail
+      const message =
+        detail ||
+        resp?.username?.[0] ||
+        resp?.email?.[0] ||
+        'Unable to complete registration.'
+      setError(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
   return (
-    <Container sx={{ py: 4 }}>
-      <Typography variant="h4" gutterBottom>
-        Register
-      </Typography>
-      <Typography variant="body1">User onboarding will be implemented in a future iteration.</Typography>
-    </Container>
+    <Box sx={{ py: 4, display: 'flex', justifyContent: 'center' }}>
+      <Card sx={{ maxWidth: 720, width: '100%' }} variant="outlined">
+        <CardContent>
+          <Typography variant="h4" gutterBottom>
+            Register
+          </Typography>
+          <Typography color="text.secondary" sx={{ mb: 2 }}>
+            Create a customer account to book vehicles.
+          </Typography>
+          <ErrorAlert message={error} />
+          {success && (
+            <Card variant="outlined" sx={{ mb: 2, borderColor: 'success.main' }}>
+              <CardContent>
+                <Typography color="success.main">{success}</Typography>
+              </CardContent>
+            </Card>
+          )}
+          <Stack component="form" spacing={2} onSubmit={handleSubmit(onSubmit)}>
+            <Grid container spacing={2}>
+              <Grid item xs={12} md={6}>
+                <TextField
+                  label="Username"
+                  fullWidth
+                  {...register('username', { required: 'Username is required' })}
+                  error={Boolean(errors.username)}
+                  helperText={errors.username?.message}
+                />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <TextField
+                  label="Email"
+                  fullWidth
+                  type="email"
+                  {...register('email', { required: 'Email is required' })}
+                  error={Boolean(errors.email)}
+                  helperText={errors.email?.message}
+                />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <TextField
+                  label="Password"
+                  type="password"
+                  fullWidth
+                  {...register('password', {
+                    required: 'Password is required',
+                    minLength: { value: 8, message: 'Min 8 characters' }
+                  })}
+                  error={Boolean(errors.password)}
+                  helperText={errors.password?.message}
+                />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <TextField
+                  label="Full name"
+                  fullWidth
+                  {...register('full_name', { required: 'Full name is required' })}
+                  error={Boolean(errors.full_name)}
+                  helperText={errors.full_name?.message}
+                />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <TextField
+                  label="Phone"
+                  fullWidth
+                  {...register('phone', { required: 'Phone is required' })}
+                  error={Boolean(errors.phone)}
+                  helperText={errors.phone?.message}
+                />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <TextField
+                  label="Driver license number"
+                  fullWidth
+                  {...register('driver_license_no', {
+                    required: 'Driver license number is required'
+                  })}
+                  error={Boolean(errors.driver_license_no)}
+                  helperText={errors.driver_license_no?.message}
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  label="Address"
+                  fullWidth
+                  multiline
+                  minRows={2}
+                  {...register('address', { required: 'Address is required' })}
+                  error={Boolean(errors.address)}
+                  helperText={errors.address?.message}
+                />
+              </Grid>
+            </Grid>
+            <Button type="submit" variant="contained" disabled={submitting}>
+              {submitting ? 'Creating...' : 'Create account'}
+            </Button>
+          </Stack>
+          <Typography sx={{ mt: 2 }}>
+            Already registered?{' '}
+            <RouterLink to="/login" style={{ textDecoration: 'none' }}>
+              Login
+            </RouterLink>
+          </Typography>
+        </CardContent>
+      </Card>
+    </Box>
   )
 }
 

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,0 +1,34 @@
+import apiClient from '../api/client'
+import { AuthTokens, User } from '../types'
+
+const authService = {
+  async login(payload: { username: string; password: string }): Promise<AuthTokens> {
+    const response = await apiClient.post('/auth/login/', payload)
+    return { access: response.data.access, refresh: response.data.refresh }
+  },
+
+  async register(payload: {
+    username: string
+    email: string
+    password: string
+    full_name: string
+    phone: string
+    driver_license_no: string
+    address: string
+  }): Promise<User> {
+    const response = await apiClient.post('/auth/register/', payload)
+    return response.data as User
+  },
+
+  async refresh(refresh: string): Promise<AuthTokens> {
+    const response = await apiClient.post('/auth/refresh/', { refresh })
+    return { access: response.data.access, refresh: response.data.refresh ?? refresh }
+  },
+
+  async me(): Promise<User> {
+    const response = await apiClient.get('/auth/me/')
+    return response.data as User
+  }
+}
+
+export default authService

--- a/frontend/src/services/bookingService.ts
+++ b/frontend/src/services/bookingService.ts
@@ -1,0 +1,85 @@
+import apiClient from '../api/client'
+import { Booking, Fine } from '../types'
+
+export interface BookingPayload {
+  car_id: string
+  start_date: string
+  end_date: string
+}
+
+const bookingService = {
+  async listBookings(): Promise<{ results: Booking[]; count?: number }> {
+    const response = await apiClient.get('/bookings/')
+    if (Array.isArray(response.data)) {
+      return { results: response.data }
+    }
+    return { results: response.data.results ?? [], count: response.data.count }
+  },
+
+  async getBooking(id: string): Promise<Booking> {
+    const response = await apiClient.get(`/bookings/${id}/`)
+    return response.data as Booking
+  },
+
+  async createBooking(payload: BookingPayload): Promise<Booking> {
+    const response = await apiClient.post('/bookings/', payload)
+    return response.data as Booking
+  },
+
+  async cancelBooking(id: string): Promise<Booking> {
+    const response = await apiClient.post(`/bookings/${id}/cancel/`)
+    return response.data as Booking
+  },
+
+  async confirmBooking(id: string): Promise<Booking> {
+    const response = await apiClient.post(`/bookings/${id}/confirm/`)
+    return response.data as Booking
+  },
+
+  async checkinBooking(id: string): Promise<Booking> {
+    const response = await apiClient.post(`/bookings/${id}/checkin/`)
+    return response.data as Booking
+  },
+
+  async returnBooking(id: string): Promise<Booking> {
+    const response = await apiClient.post(`/bookings/${id}/return/`)
+    return response.data as Booking
+  },
+
+  async listFines(id: string): Promise<Fine[]> {
+    const response = await apiClient.get(`/bookings/${id}/fines/`)
+    return response.data as Fine[]
+  },
+
+  async addFine(
+    id: string,
+    payload: { type: Fine['type']; amount: string; notes?: string }
+  ): Promise<Fine> {
+    const response = await apiClient.post(`/bookings/${id}/fines/`, payload)
+    return response.data as Fine
+  },
+
+  async holdDeposit(id: string, amount: string) {
+    const response = await apiClient.post(`/bookings/${id}/deposit/hold/`, { amount })
+    return response.data
+  },
+
+  async releaseDeposit(id: string, partial = false) {
+    const response = await apiClient.post(`/bookings/${id}/deposit/release/`, {
+      partial
+    })
+    return response.data
+  },
+
+  async forfeitDeposit(id: string) {
+    const response = await apiClient.post(`/bookings/${id}/deposit/forfeit/`)
+    return response.data
+  },
+
+  async payInvoice(id: string, method = 'card') {
+    const response = await apiClient.post(`/bookings/${id}/invoice/pay/`, { method })
+    return response.data
+  }
+}
+
+export default bookingService

--- a/frontend/src/services/carService.ts
+++ b/frontend/src/services/carService.ts
@@ -1,0 +1,44 @@
+import apiClient from '../api/client'
+import { Car } from '../types'
+
+export interface CarFilters {
+  make?: string
+  model?: string
+  type?: string
+  status?: string
+  year_min?: string
+  year_max?: string
+  search?: string
+  page?: number
+}
+
+const carService = {
+  async listCars(filters: CarFilters = {}): Promise<{ results: Car[]; count?: number }> {
+    const response = await apiClient.get('/cars/', { params: filters })
+    if (Array.isArray(response.data)) {
+      return { results: response.data }
+    }
+    return { results: response.data.results ?? [], count: response.data.count }
+  },
+
+  async getCar(id: string): Promise<Car> {
+    const response = await apiClient.get(`/cars/${id}/`)
+    return response.data as Car
+  },
+
+  async createCar(payload: Omit<Car, 'id'>): Promise<Car> {
+    const response = await apiClient.post('/cars/', payload)
+    return response.data as Car
+  },
+
+  async updateCar(id: string, payload: Partial<Car>): Promise<Car> {
+    const response = await apiClient.patch(`/cars/${id}/`, payload)
+    return response.data as Car
+  },
+
+  async deleteCar(id: string): Promise<void> {
+    await apiClient.delete(`/cars/${id}/`)
+  }
+}
+
+export default carService

--- a/frontend/src/services/pricingService.ts
+++ b/frontend/src/services/pricingService.ts
@@ -1,0 +1,13 @@
+import apiClient from '../api/client'
+import { QuoteResponse } from '../types'
+
+const pricingService = {
+  async quote(carId: string, start: string, end: string): Promise<QuoteResponse> {
+    const response = await apiClient.get('/pricing/quote/', {
+      params: { car: carId, start, end }
+    })
+    return response.data as QuoteResponse
+  }
+}
+
+export default pricingService

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,86 @@
+export type UserRole = 'customer' | 'manager' | 'admin'
+
+export interface CustomerProfile {
+  full_name: string
+  phone: string
+  driver_license_no: string
+  address: string
+}
+
+export interface User {
+  id: string
+  username: string
+  email: string
+  role: UserRole
+  profile?: CustomerProfile
+}
+
+export interface AuthTokens {
+  access: string
+  refresh: string
+}
+
+export interface Car {
+  id: string
+  make: string
+  model: string
+  year: number
+  vin: string
+  type: string
+  base_price_per_day: string
+  status: 'available' | 'reserved' | 'rented' | 'service'
+  mileage: number
+  last_service_at?: string | null
+}
+
+export interface Booking {
+  id: string
+  customer: string
+  car: Car
+  start_date: string
+  end_date: string
+  status: 'pending' | 'confirmed' | 'active' | 'completed' | 'canceled'
+  created_at: string
+  updated_at: string
+  fines: Fine[]
+  deposit?: Deposit
+  invoice?: Invoice
+}
+
+export interface Fine {
+  id: string
+  type: 'damage' | 'late_return' | 'cleaning' | 'other'
+  amount: string
+  notes?: string
+  assessed_at: string
+}
+
+export interface Deposit {
+  id: string
+  amount: string
+  status: 'held' | 'released' | 'partially_released' | 'forfeited'
+  txn_ref?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface Invoice {
+  id: string
+  breakdown: Array<{ label: string; amount: string }>
+  total: string
+  paid_at?: string | null
+  method?: string
+  payment_reference?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface QuoteBreakdownItem {
+  label: string
+  amount: string
+}
+
+export interface QuoteResponse {
+  total: string
+  breakdown: QuoteBreakdownItem[]
+}


### PR DESCRIPTION
## Summary
- add JWT-aware axios client, auth context, and protected routing with role-based navigation
- implement public car browsing with quotes/bookings plus customer booking detail views
- add manager/admin fleet CRUD, booking queue actions, and frontend env/readme updates

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433132d714833394ac32568d3b1136)